### PR TITLE
add dependencies for desktop linux builds

### DIFF
--- a/linux/Dockerfile
+++ b/linux/Dockerfile
@@ -11,10 +11,13 @@ RUN apt-get update \
         curl \
         file \
         git \
+        libblkid-dev \
         libglu1-mesa \
+        libgtk-3-dev \
         libxinerama1 \
         libxcursor1 \
         libxrandr2 \
+        pkg-config \
         ninja-build \
         unzip \
         xz-utils \


### PR DESCRIPTION
This adds missing dependencies for building Flutter Linux desktop apps as per `flutter doctor` advice:

```
✗] Linux toolchain - develop for Linux desktop
    ✗ pgk-config is required for Linux development.
      It is likely available from your distribution (e.g.: apt install pkg-config), or can be downloaded from
      https://www.freedesktop.org/wiki/Software/pkg-config/
    ✗ GTK 3.0 development libraries are required for Linux development.
      They are likely available from your distribution (e.g.: apt install libgtk-3-dev)
    ✗ The blkid development library is required for Linux development.
      It is likely available from your distribution (e.g.: apt install libblkid-dev)
```

After applying these changes I was able to build a linux desktop app successfully in a local container built using this updated Dockerfile.