### PR TITLE
Don't use --depth 1 while cloning flutter

### DIFF
--- a/linux/Dockerfile
+++ b/linux/Dockerfile
@@ -26,7 +26,7 @@ RUN apt-get update \
     && apt-get autoclean \
     && rm -rf /var/lib/apt/lists/*
 
-RUN git clone https://github.com/flutter/flutter.git -b master --depth 1 /opt/flutter
+RUN git clone https://github.com/flutter/flutter.git -b master /opt/flutter
 
 RUN flutter upgrade \
     && flutter config --enable-linux-desktop \


### PR DESCRIPTION
Shallow clone results into Flutter version `Flutter 0.0.0-unknown` which fail builds since most of flutter repos have constraints e.g.

```
environment:
  sdk: ">=2.1.0 <3.0.0"
  flutter: ">=1.12.13+hotfix.5 <2.0.0"
```

It was introduced 4 days ago here https://github.com/codemagic-ci-cd/flutter-desktop-docker/commit/d3acca4ee20614c237a3ba04d34342a1f5a1389e#diff-caf90169eefa5f807d577486b9f795ab86ae2983c5c20806cff959117e90af18